### PR TITLE
Use ubuntu20.04 for now

### DIFF
--- a/.github/workflows/give_kudos.yml
+++ b/.github/workflows/give_kudos.yml
@@ -11,7 +11,7 @@ env:
   STRAVA_PASSWORD: ${{ secrets.STRAVA_PASSWORD }}
 jobs:
   run-kudos-cron:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3 
       - uses: actions/setup-python@v4


### PR DESCRIPTION
Use Ubuntu 20.04 instead of latest as the latest is raising an error: version 3.7.6 with arch x64 not found (it is a listed version)